### PR TITLE
To read excel file resources using FileSystemResource, remove unneces…

### DIFF
--- a/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiItemReader.java
+++ b/spring-batch-excel/src/main/java/org/springframework/batch/item/excel/poi/PoiItemReader.java
@@ -25,7 +25,6 @@ import org.springframework.core.io.Resource;
 
 import java.io.Closeable;
 import java.io.InputStream;
-import java.io.PushbackInputStream;
 
 /**
  * {@link org.springframework.batch.item.ItemReader} implementation which uses apache POI to read an Excel
@@ -78,9 +77,7 @@ public class PoiItemReader<T> extends AbstractExcelItemReader<T> {
     @Override
     protected void openExcelFile(final Resource resource) throws Exception {
         workbookStream = resource.getInputStream();
-        if (!workbookStream.markSupported() && !(workbookStream instanceof PushbackInputStream)) {
-            throw new IllegalStateException("InputStream MUST either support mark/reset, or be wrapped as a PushbackInputStream");
-        }
+
         this.workbook = WorkbookFactory.create(workbookStream);
         this.workbook.setMissingCellPolicy(Row.CREATE_NULL_AS_BLANK);
     }


### PR DESCRIPTION
…sary validation check in PoiItemReader.openExcelFile method

Validation check is unnecessary because WorkbookFactory.create(InputStream inp) wrap InputStream as PushBackInputStream when that InputStream isn’t marksupported